### PR TITLE
[BUGFIX] fix empty broken links list for non-admins

### DIFF
--- a/Classes/Widgets/BrokenLinksWidget.php
+++ b/Classes/Widgets/BrokenLinksWidget.php
@@ -101,6 +101,10 @@ class BrokenLinksWidget implements WidgetInterface
 
     protected function getSearchFields(): array
     {
-        return BackendUtility::getPagesTSconfig(self::PAGE_ID)['mod.']['linkvalidator.']['searchFields.'] ?? [];
+        $searchFieldMapping = BackendUtility::getPagesTSconfig(self::PAGE_ID)['mod.']['linkvalidator.']['searchFields.'] ?? [];
+        foreach ($searchFieldMapping as $table => $searchFields) {
+            $searchFieldMapping[$table] = GeneralUtility::trimExplode(',', $searchFields);
+        }
+        return $searchFieldMapping;
     }
 }


### PR DESCRIPTION
For Editors the list was always empty. I had to dig deep to find out that the searchFields from linkvalidator configuration needs to be processed. 