### PR TITLE
[TASK] Improve performance for duplicate files widget

### DIFF
--- a/Classes/Widgets/DuplicateFilesWidget.php
+++ b/Classes/Widgets/DuplicateFilesWidget.php
@@ -85,8 +85,7 @@ final class DuplicateFilesWidget implements WidgetInterface, RequestAwareWidgetI
             ->select('uid', 'sha1')
             ->from('sys_file')
             ->where(
-                $queryBuilder->expr()->in('sha1', $queryBuilder->createNamedParameter($duplicatedSha1, ArrayParameterType::STRING)),
-
+                $queryBuilder->expr()->in('sha1', $queryBuilder->createNamedParameter($duplicatedSha1, ArrayParameterType::STRING))
             )
             ->executeQuery()
             ->fetchAllKeyValue();


### PR DESCRIPTION
This PR improves widget performance by querying the duplicated uids at once. `sys_files` with empty sha1 are excluded.