### PR TITLE
[FEATURE] Exclude paths in duplicate files widget

### DIFF
--- a/Classes/Widgets/DuplicateFilesWidget.php
+++ b/Classes/Widgets/DuplicateFilesWidget.php
@@ -85,8 +85,7 @@ final class DuplicateFilesWidget implements WidgetInterface, RequestAwareWidgetI
             ->select('uid', 'sha1')
             ->from('sys_file')
             ->where(
-                $queryBuilder->expr()->in('sha1', $queryBuilder->createNamedParameter($duplicatedSha1, ArrayParameterType::STRING)),
-
+                $queryBuilder->expr()->in('sha1', $queryBuilder->createNamedParameter($duplicatedSha1, ArrayParameterType::STRING))
             )
             ->executeQuery()
             ->fetchAllKeyValue();


### PR DESCRIPTION
This PR introduces a new `excludedPaths` option to the `DuplicateFilesWidget`.
This feature allows you to exclude specific directories where duplicate files are expected but not relevant, helping reduce noise in the results.

To enable this option in your project, you’ll need to redefine the entire widget, as the Symfony service container does not support partial service configuration overrides. Alternatively, we could consider moving this setting to the ExtensionConfiguration for easier integration—this change can be explored if there's interest in adopting the feature.

Current configuration via **Services.yaml**:
```yaml
  Sitegeist\EditorWidgets\Widgets\DuplicateFilesWidget:
    tags:
        - name: dashboard.widget
          title: 'LLL:EXT:editor_widgets/Resources/Private/Language/locallang.xlf:widgets.duplicateFiles.title'
          description: 'LLL:EXT:editor_widgets/Resources/Private/Language/locallang.xlf:widgets.duplicateFiles.description'
          width: medium
          height: medium
          additionalCssClasses: 'sitegeist-editor-widgets'
          groupNames: systemInfo
          iconIdentifier: editor-widgets
    arguments:
      $options:
        excludedPaths: [ '1:firstPath', '3:/second/path' ]
```

EDIT: This PR includes #19 !!