### PR TITLE
[BUGFIX] Reorder constructor parameters in BrokenLinksWidget

### DIFF
--- a/Classes/Widgets/BrokenLinksWidget.php
+++ b/Classes/Widgets/BrokenLinksWidget.php
@@ -37,11 +37,11 @@ final class BrokenLinksWidget implements WidgetInterface, RequestAwareWidgetInte
 
     public function __construct(
         private readonly BackendViewFactory $backendViewFactory,
-        private readonly ?BrokenLinkRepository $brokenLinkRepository = null,
         private readonly ConnectionPool $connectionPool,
+        private readonly WidgetConfigurationInterface $configuration,
+        private readonly ?BrokenLinkRepository $brokenLinkRepository = null,
         private readonly ?LinktypeRegistry $linktypeRegistry = null,
         private readonly ?PagesRepository $pagesRepository = null,
-        private readonly WidgetConfigurationInterface $configuration,
         private readonly array $options = []
     ) {
     }


### PR DESCRIPTION
This pull request updates the constructor parameters of the `BrokenLinksWidget` to prevent PHP deprecation messages.

```
PHP Deprecated:  Optional parameter $brokenLinkRepository declared before required parameter $configuration is implicitly treated as a required parameter in /var/www/html/packages/editor-widgets/Classes/Widgets/BrokenLinksWidget.php on line 38
```